### PR TITLE
Bug Fixes + QOL

### DIFF
--- a/lib/cai/ess/helpers.ex
+++ b/lib/cai/ess/helpers.ex
@@ -21,13 +21,17 @@ defmodule CAI.ESS.Helpers do
   - other_id
   - experience_id
   """
-  @spec consecutive?(map(), map()) :: boolean()
-  def consecutive?(%mod1{} = e1, %mod2{} = e2) do
+  @spec consecutive?(map(), map(), list(), list()) :: boolean()
+  def consecutive?(%mod1{} = e1, %mod2{} = e2, bonuses1 \\ [], bonuses2 \\ []) do
     mod1 == mod2 and
       Map.get(e1, :character_id) == Map.get(e2, :character_id) and
+      Map.get(e1, :character_loadout_id) == Map.get(e2, :character_loadout_id) and
       Map.get(e1, :attacker_character_id) == Map.get(e2, :attacker_character_id) and
+      Map.get(e1, :attacker_loadout_id) == Map.get(e2, :attacker_loadout_id) and
+      Map.get(e1, :attacker_weapon_id) == Map.get(e2, :attacker_weapon_id) and
       Map.get(e1, :other_id) == Map.get(e2, :other_id) and
-      Map.get(e1, :experience_id) == Map.get(e2, :experience_id)
+      Map.get(e1, :experience_id) == Map.get(e2, :experience_id) and
+      bonuses1 == bonuses2
   end
 
   @doc """

--- a/lib/cai_web/live/session_live.ex
+++ b/lib/cai_web/live/session_live.ex
@@ -19,6 +19,7 @@ defmodule CAIWeb.SessionLive do
         value={@ref}
         type="text"
         errors={@ref_errors}
+        autofocus
       />
       <.button class="mt-2 bg-gray-800">Search</.button>
     </form>
@@ -27,7 +28,13 @@ defmodule CAIWeb.SessionLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket |> assign(:ref, "") |> assign(:ref_errors, [])}
+    {
+      :ok,
+      socket
+      |> assign(:ref, "")
+      |> assign(:ref_errors, [])
+      |> assign(:page_title, "Search for a Character")
+    }
   end
 
   @impl true

--- a/lib/cai_web/live/session_live/entry.ex
+++ b/lib/cai_web/live/session_live/entry.ex
@@ -106,12 +106,12 @@ defmodule CAIWeb.SessionLive.Entry do
   end
 
   defp map(
-         [%Entry{event: prev_e1} = prev_entry1, %Entry{event: prev_e2, count: prev_count} = prev_entry2 | mapped],
+         [%Entry{} = prev_entry1, %Entry{count: prev_count} = prev_entry2 | mapped],
          [e | rem_events],
          character,
          other_char_map
        ) do
-    if Helpers.consecutive?(prev_e1, prev_e2) do
+    if Helpers.consecutive?(prev_entry1.event, prev_entry2.event, prev_entry1.bonuses, prev_entry2.bonuses) do
       map([%Entry{prev_entry2 | count: prev_count + 1} | mapped], [e | rem_events], character, other_char_map)
     else
       other = Helpers.get_other_character(character.character_id, e, &Map.fetch(other_char_map, &1))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CAI.MixProject do
   def project do
     [
       app: :cai,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/cai_web/live/session_live_test.exs
+++ b/test/cai_web/live/session_live_test.exs
@@ -4,6 +4,8 @@ defmodule CAIWeb.SessionLiveTest do
   import Phoenix.LiveViewTest
   import CAI.CharactersFixtures
 
+  alias CAI.Characters.Character
+
   @create_attrs %{character: 42, faction_id: 42, name: "some name"}
   @update_attrs %{character: 43, faction_id: 43, name: "some updated name"}
   @invalid_attrs %{character: nil, faction_id: nil, name: nil}
@@ -31,6 +33,134 @@ defmodule CAIWeb.SessionLiveTest do
 
       assert html =~ "Aggregate Stats"
       assert html =~ "Event Feed"
+    end
+  end
+
+  describe "Entry.map/2" do
+    alias CAIWeb.SessionLive.Entry
+    @koremotsuetr 5_428_491_127_580_230_897
+
+    @tag :regression
+    test "will not combine 2 deaths with different weapon IDs" do
+      # this bug was observed with KoremotsueTR's session from 7/22/2023 @ 8:53:22 PM to 7/22/2023 @ 9:00:23 PM PST
+      character = %Character{character_id: @koremotsuetr}
+
+      # The logic for condensing happens on the last two *mapped* entries, so the end of this list contains an extra
+      # 291 (Ribbon Experience) GE event to make sure we hit that logic (this was also an event during the actual
+      # session)
+      event_history = [
+        %CAI.ESS.GainExperience{
+          amount: 500,
+          character_id: 5_428_440_051_057_603_985,
+          experience_id: 593,
+          loadout_id: 5,
+          other_id: 5_428_491_127_580_230_897,
+          team_id: 2,
+          timestamp: 1_690_084_788,
+          world_id: 1,
+          zone_id: 2
+        },
+        %CAI.ESS.GainExperience{
+          amount: 200,
+          character_id: 5_428_440_051_057_603_985,
+          experience_id: 1,
+          loadout_id: 5,
+          other_id: 5_428_491_127_580_230_897,
+          team_id: 2,
+          timestamp: 1_690_084_788,
+          world_id: 1,
+          zone_id: 2
+        },
+        %CAI.ESS.Death{
+          character_id: 5_428_491_127_580_230_897,
+          timestamp: 1_690_084_788,
+          attacker_character_id: 5_428_440_051_057_603_985,
+          attacker_fire_mode_id: 661,
+          attacker_loadout_id: 5,
+          attacker_team_id: 2,
+          attacker_vehicle_id: 0,
+          attacker_weapon_id: 1044,
+          character_loadout_id: 8,
+          is_critical: false,
+          is_headshot: false,
+          team_id: 3,
+          world_id: 1,
+          zone_id: 2
+        },
+        %CAI.ESS.GainExperience{
+          amount: 600,
+          character_id: 5_428_440_051_057_603_985,
+          experience_id: 279,
+          loadout_id: 5,
+          other_id: 5_428_491_127_580_230_897,
+          team_id: 2,
+          timestamp: 1_690_084_760,
+          world_id: 1,
+          zone_id: 2
+        },
+        %CAI.ESS.GainExperience{
+          amount: 50,
+          character_id: 5_428_440_051_057_603_985,
+          experience_id: 38,
+          loadout_id: 5,
+          other_id: 5_428_491_127_580_230_897,
+          team_id: 2,
+          timestamp: 1_690_084_760,
+          world_id: 1,
+          zone_id: 2
+        },
+        %CAI.ESS.GainExperience{
+          amount: 500,
+          character_id: 5_428_440_051_057_603_985,
+          experience_id: 593,
+          loadout_id: 5,
+          other_id: 5_428_491_127_580_230_897,
+          team_id: 2,
+          timestamp: 1_690_084_760,
+          world_id: 1,
+          zone_id: 2
+        },
+        %CAI.ESS.Death{
+          character_id: 5_428_491_127_580_230_897,
+          timestamp: 1_690_084_760,
+          attacker_character_id: 5_428_440_051_057_603_985,
+          attacker_fire_mode_id: 680,
+          attacker_loadout_id: 5,
+          attacker_team_id: 2,
+          attacker_vehicle_id: 0,
+          attacker_weapon_id: 880,
+          character_loadout_id: 8,
+          is_critical: false,
+          is_headshot: false,
+          team_id: 3,
+          world_id: 1,
+          zone_id: 2
+        },
+        %CAI.ESS.GainExperience{
+          amount: 500,
+          character_id: 5_428_491_127_580_230_897,
+          experience_id: 291,
+          loadout_id: 8,
+          other_id: 0,
+          team_id: 3,
+          timestamp: 1_690_084_754,
+          world_id: 1,
+          zone_id: 2
+        }
+      ]
+
+      entries = Entry.map(event_history, character)
+
+      assert 3 == length(entries)
+
+      assert [
+               %Entry{count: 1, event: %CAI.ESS.Death{}, bonuses: bonuses1},
+               %Entry{count: 1, event: %CAI.ESS.Death{}, bonuses: bonuses2},
+               _ribbon_xp
+             ] = entries
+
+      assert 2 == length(bonuses1)
+      assert 3 == length(bonuses2)
     end
   end
 end


### PR DESCRIPTION
- `Helpers.consecutive?/4` has more checks (including entry bonuses where applicable) to avoid condensing entries that should stay separate
- page title on `SearchLive` now updates
- autofocus search box in `SessionLive`