### PR TITLE
Refactor Entries' Event character-ID-to-character mappings

### DIFF
--- a/lib/cai/cachex/static_data_warmer/getters.ex
+++ b/lib/cai/cachex/static_data_warmer/getters.ex
@@ -247,7 +247,7 @@ defmodule CAI.Cachex.StaticDataWarmer.Getters do
       "2133" => {450, PS2.API.get_image_url("/files/ps2/images/static/77937.png")},
       "2134" => {450, PS2.API.get_image_url("/files/ps2/images/static/77943.png")},
       "2135" => {450, PS2.API.get_image_url("/files/ps2/images/static/77939.png")},
-      "2136" => {350, PS2.API.get_image_url("/files/ps2/images/static/39607.png")},
+      "2136" => {350, PS2.API.get_image_url("/files/ps2/images/static/93607.png")},
       "2137" => {450, "/images/93604.png"},
       "2139" => {200, PS2.API.get_image_url("/files/ps2/images/static/77942.png")},
       "2140" => {450, PS2.API.get_image_url("/files/ps2/images/static/77933.png")},

--- a/lib/cai_web/components/core_components.ex
+++ b/lib/cai_web/components/core_components.ex
@@ -16,6 +16,7 @@ defmodule CAIWeb.CoreComponents do
   """
   use Phoenix.Component
 
+  alias CAIWeb.Utils
   alias Phoenix.HTML.Form
   alias Phoenix.LiveView.JS
   import CAIWeb.Gettext
@@ -638,8 +639,19 @@ defmodule CAIWeb.CoreComponents do
     <.header>
       <img class="h-20 w-20" src={CAI.factions()[@character.faction_id].image} />
 
-      <span :if={@character.outfit}>[<%= @character.outfit.alias %>]</span>
-      <%= @character.name_first %>
+      <div class="whitespace-nowrap w-[fit-content]">
+        <span :if={@character.outfit}>[<%= @character.outfit.alias %>]</span>
+        <%= @character.name_first %> |
+        Battle Rank <%= @character.battle_rank %>
+
+        <div class="h-1 bg-neutral-200 dark:bg-neutral-600" title="Progress to next Battle Rank">
+          <div
+            class={"h-1 #{Utils.faction_css_classes(@character.faction_id, nil)} brightness-150"}
+            style={"width: #{round(@character.percent_to_next_br)}%"}
+          >
+          </div>
+        </div>
+      </div>
 
       <:subtitle><%= @character.character_id %></:subtitle>
     </.header>

--- a/lib/cai_web/live/session_live/show.ex
+++ b/lib/cai_web/live/session_live/show.ex
@@ -182,7 +182,7 @@ defmodule CAIWeb.SessionLive.Show do
     liveview = self()
 
     Task.start_link(fn ->
-      entries = Entry.map(events_to_stream, character)
+      entries = Entry.map(events_to_stream, [character])
       send(liveview, {:bulk_append, entries, new_events_limit})
     end)
   end
@@ -219,7 +219,7 @@ defmodule CAIWeb.SessionLive.Show do
       {:ok, group} ->
         character = socket.assigns.character
 
-        other_map =
+        character_map =
           with [%{character_id: _} | _] <- group.bonuses,
                {_, char_id, other_id} = pending_key,
                placeholder_event = %GainExperience{character_id: char_id, other_id: other_id},
@@ -229,8 +229,9 @@ defmodule CAIWeb.SessionLive.Show do
             {:unavailable, other_id} -> %{other_id => {:unavailable, other_id}}
             _ -> %{}
           end
+          |> Map.put(character.character_id, character)
 
-        entries = Entry.from_groups(%{pending_key => group}, [], character, other_map)
+        entries = Entry.from_groups(%{pending_key => group}, [], character_map)
 
         {
           :noreply,

--- a/lib/cai_web/live/utils.ex
+++ b/lib/cai_web/live/utils.ex
@@ -58,4 +58,18 @@ defmodule CAIWeb.Utils do
 
   def safe_divide(num, denom) when denom in [0, 0.0], do: num / 1
   def safe_divide(num, denom), do: num / denom
+
+  # Can't actually store these classes in `CAI.factions` because these classes won't be compiled...
+  def faction_css_classes(faction_id, team_id) do
+    case {CAI.factions()[faction_id].alias, team_id} do
+      {"NS" <> _, 1} -> "bg-gradient-to-r from-gray-600 to-purple-600 hover:bg-gray-800"
+      {"NS" <> _, 2} -> "bg-gradient-to-r from-gray-600 to-blue-600 hover:bg-gray-800"
+      {"NS" <> _, 3} -> "bg-gradient-to-r from-gray-600 to-red-600 hover:bg-gray-800"
+      {"NS" <> _, _} -> "bg-gray-600 hover:bg-gray-800"
+      {"NC", _} -> "bg-blue-600 hover:bg-blue-800"
+      {"VS", _} -> "bg-purple-600 hover:bg-purple-800"
+      {"TR", _} -> "bg-red-600 hover:bg-red-800"
+      _ -> "bg-gray-600 hover:bg-gray-800"
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CAI.MixProject do
   def project do
     [
       app: :cai,
-      version: "0.1.7",
+      version: "0.1.8",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/cai_web/live/session_live_test.exs
+++ b/test/cai_web/live/session_live_test.exs
@@ -145,7 +145,7 @@ defmodule CAIWeb.SessionLiveTest do
         }
       ]
 
-      entries = Entry.map(event_history, character)
+      entries = Entry.map(event_history, [character])
 
       assert 3 == length(entries)
 


### PR DESCRIPTION
Prep work for #15 - logic no longer cares which character is the session character.  

Also now displaying BR/progress in the character header

also fixed a couple of bugs:
- dervish icon ID typo
- check if outfit is `nil` before trying to `alias_or_name`