### PR TITLE
Reduce Blocking Character Queries

### DIFF
--- a/lib/cai/characters.ex
+++ b/lib/cai/characters.ex
@@ -108,6 +108,26 @@ defmodule CAI.Characters do
   end
 
   @doc """
+  Similar to `fetch/1`, but immediately returns `:ok` and sends the caller a message
+  with the result of the query.
+
+  The message takes the form of `{:fetched, character_reference, query_result}`, where
+  `character_reference` is the referenced passed to this function, and `query_result`
+  is one of `{:ok, Character.t()} | :not_found | :error`
+  """
+  @spec fetch_later(character_reference()) :: :ok
+  def fetch_later(character_reference) do
+    caller = self()
+
+    Task.start_link(fn ->
+      query_result = fetch(character_reference)
+      send(caller, {:fetched, character_reference, query_result})
+    end)
+
+    :ok
+  end
+
+  @doc """
   Runs the given Census query, optionally transforming the result with the `map_to/1` parameter.
 
   Defaults to a maximum of #{@default_census_attempts} attempts. Returns the same as `fetch/1`.

--- a/lib/cai/ess/helpers.ex
+++ b/lib/cai/ess/helpers.ex
@@ -86,7 +86,6 @@ defmodule CAI.ESS.Helpers do
         other
 
       {:ok, other_id} ->
-        IO.inspect other_id, label: "other id get_other_character"
         {:being_fetched, other_id}
 
       {{:ok, :not_found}, other_id} ->

--- a/lib/cai/ess/helpers.ex
+++ b/lib/cai/ess/helpers.ex
@@ -72,7 +72,8 @@ defmodule CAI.ESS.Helpers do
 
   Given `this_character_id`, an ESS event, and (optionally) a fetch function, will get the other Character for the
   event. Will return `:noop` if the event does not contain a second character ID. If the fetch function does not return
-  `{:ok, Character.t()}`, this function will return `{:unavailable, other_id}`
+  `:ok` or `{:ok, Character.t()}`, this function will return `{:unavailable, other_id}`. If the fetch function returns
+  `:ok` specifically, `{:being_fetched, other_id}` is returned.
   """
   def get_other_character(this_char_id, event, fetch_fn \\ &Characters.fetch/1)
 
@@ -83,6 +84,10 @@ defmodule CAI.ESS.Helpers do
 
       {{:ok, %Character{} = other}, _other_id} ->
         other
+
+      {:ok, other_id} ->
+        IO.inspect other_id, label: "other id get_other_character"
+        {:being_fetched, other_id}
 
       {{:ok, :not_found}, other_id} ->
         Logger.info("Character ID not_found: #{other_id}")

--- a/lib/cai_web/components/event_feed/utils.ex
+++ b/lib/cai_web/components/event_feed/utils.ex
@@ -19,6 +19,10 @@ defmodule CAIWeb.EventFeed.Utils do
 
   def link_character(maybe_character, opts \\ [])
 
+  def link_character({:being_fetched, character_id}, opts) do
+    link_character(%Character{character_id: character_id, name_first: "Getting name...", faction_id: 0}, opts)
+  end
+
   def link_character({:unavailable, character_id}, opts) when is_character_id(character_id) do
     possessive? = Keyword.get(opts, :possessive?, false)
 

--- a/lib/cai_web/live/session_live/blurbs.ex
+++ b/lib/cai_web/live/session_live/blurbs.ex
@@ -75,15 +75,7 @@ defmodule CAIWeb.SessionLive.Blurbs do
         # if the track_queue is empty and we're not currently playing anything, play the sound directly.
         # Otherwise, enqueue.
         if match?([], state.track_queue) and not state.playing? do
-          case get_random_blurb_filename(category, state) do
-            {:ok, track_filename} ->
-              socket
-              |> push_event("play-blurb", %{"track" => track_filename})
-              |> Model.put(:blurbs, {:enabled, %Blurbs{state | playing?: true}})
-
-            :error ->
-              socket
-          end
+          play_blurb(category, socket, state)
         else
           # This may be slow, but it's simple, and I don't forsee an obsurd amount of tracks building up
           # The worst case I can think of is mass-death events from e.g. orbital strikes.
@@ -99,12 +91,25 @@ defmodule CAIWeb.SessionLive.Blurbs do
   end
 
   def get_random_blurb_filename(category, %Blurbs{} = state) do
-    with filenames <- get_in(@blurbs, [state.voicepack, category]) do
-      {:ok, Enum.random(filenames)}
-    else
+    case @blurbs[state.voicepack][category] do
+      filenames when not is_nil(filenames) ->
+        {:ok, Enum.random(filenames)}
+
       uhoh ->
         Logger.error("Unable to play blurb: #{inspect(uhoh)}")
         :error
+    end
+  end
+
+  defp play_blurb(category, socket, state) do
+    case get_random_blurb_filename(category, state) do
+      {:ok, track_filename} ->
+        socket
+        |> push_event("play-blurb", %{"track" => track_filename})
+        |> Model.put(:blurbs, {:enabled, %Blurbs{state | playing?: true}})
+
+      :error ->
+        socket
     end
   end
 

--- a/lib/cai_web/live/session_live/blurbs.ex
+++ b/lib/cai_web/live/session_live/blurbs.ex
@@ -40,12 +40,17 @@ defmodule CAIWeb.SessionLive.Blurbs do
 
   def voicepacks, do: @voicepacks
 
-  def track_paths(voicepack) do
+  def track_paths(voicepack) when voicepack in @voicepacks do
     category_map = Map.fetch!(@blurbs, voicepack)
 
     for {_category, filenames} <- category_map, filename <- filenames, into: MapSet.new() do
       ~p"/audio/voicepacks/#{voicepack}/tracks/#{filename}"
     end
+  end
+
+  def track_paths(voicepack) do
+    Logger.warning("No voicepack called '#{voicepack}' available.")
+    []
   end
 
   defstruct killing_spree_count: 0,

--- a/lib/cai_web/live/session_live/entry.ex
+++ b/lib/cai_web/live/session_live/entry.ex
@@ -27,10 +27,12 @@ defmodule CAIWeb.SessionLive.Entry do
   defstruct event: nil, character: nil, other: :none, count: 1, bonuses: []
   @type t :: %__MODULE__{}
 
+  @type other_character :: Character.t() | {:being_fetched, Characters.character_id()} | :none
+
   @doc """
   Create a new Entry struct
   """
-  @spec new(event :: map(), character :: Character.t(), other :: Character.t() | :none, integer(), [map()]) :: Entry.t()
+  @spec new(event :: map(), character :: Character.t(), other :: other_character(), integer(), [map()]) :: Entry.t()
   def new(event, character, other \\ :none, count \\ 1, bonuses \\ []) do
     %Entry{event: event, character: character, other: other, count: count, bonuses: bonuses}
   end
@@ -144,6 +146,7 @@ defmodule CAIWeb.SessionLive.Entry do
     case Map.get(character_map, character_id) do
       %Character{} = c -> c
       {:unavailable, other_id} -> {:unavailable, other_id}
+      {:being_fetched, other_id} -> {:being_fetched, other_id |> IO.inspect(label: "other id")}
       res when res in [nil, :not_found, :error] -> {:unavailable, character_id}
     end
   end

--- a/lib/cai_web/live/session_live/entry.ex
+++ b/lib/cai_web/live/session_live/entry.ex
@@ -146,7 +146,7 @@ defmodule CAIWeb.SessionLive.Entry do
     case Map.get(character_map, character_id) do
       %Character{} = c -> c
       {:unavailable, other_id} -> {:unavailable, other_id}
-      {:being_fetched, other_id} -> {:being_fetched, other_id |> IO.inspect(label: "other id")}
+      {:being_fetched, other_id} -> {:being_fetched, other_id}
       res when res in [nil, :not_found, :error] -> {:unavailable, character_id}
     end
   end

--- a/lib/cai_web/live/session_live/show.html.heex
+++ b/lib/cai_web/live/session_live/show.html.heex
@@ -55,7 +55,7 @@
         value={elem(@model.blurbs, 1).volume}
         phx-hook="BlurbVolumeControl"
         phx-debounce="120"
-      >
+      />
     </.simple_form>
 
     <.button :if={@model.live?} id="toggle-blurbs-button" phx-click="toggle-blurbs">

--- a/lib/cai_web/live/session_live/show/model.ex
+++ b/lib/cai_web/live/session_live/show/model.ex
@@ -15,6 +15,7 @@ defmodule CAIWeb.SessionLive.Show.Model do
   defdelegate pop(v, key), to: Map
 
   defstruct aggregates: Map.new(Session.aggregate_fields(), &{&1, 0}),
+            blurbs: :disabled,
             character: nil,
             events_limit: 15,
             last_entry: nil,
@@ -22,7 +23,7 @@ defmodule CAIWeb.SessionLive.Show.Model do
             loading_more?: false,
             page_title: "Character Session",
             pending_groups: %{},
-            blurbs: :disabled,
+            pending_queries: %{},
             remaining_events: [],
             timestamps: nil
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CAI.MixProject do
   def project do
     [
       app: :cai,
-      version: "0.1.12",
+      version: "0.1.13",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Introduces `Characters.fetch_later/1` to reduce blocking on a live game session during long character queries

Also makes sure the given voicepack is an actual option when getting track paths