### PR TITLE
temp fix for swapped chars in live sessions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CAI.MixProject do
   def project do
     [
       app: :cai,
-      version: "0.1.15",
+      version: "0.1.16",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
When the LV character was under the `attacker_character_id` or `other_id` fields, their `%Character{}` was put in the primary `character_id` slot in live sessions. This is a temp fix...not very pretty. Once ratelimiter is in this whole flow will be revisited